### PR TITLE
General improvements to install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,23 +1,30 @@
 #!/bin/sh
 
-set -e # -e: exit on error
+# -e: exit on error
+# -u: exit on unset variables
+set -eu
 
-if [ ! "$(command -v chezmoi)" ]; then
-  bin_dir="$HOME/.local/bin"
-  chezmoi="$bin_dir/chezmoi"
-  if [ "$(command -v curl)" ]; then
-    sh -c "$(curl -fsSL https://git.io/chezmoi)" -- -b "$bin_dir"
-  elif [ "$(command -v wget)" ]; then
-    sh -c "$(wget -qO- https://git.io/chezmoi)" -- -b "$bin_dir"
+if ! chezmoi="$(command -v chezmoi)"; then
+  bin_dir="${HOME}/.local/bin"
+  chezmoi="${bin_dir}/chezmoi"
+  echo "Installing chezmoi to '${chezmoi}'" >&2
+  if command -v curl >/dev/null; then
+    chezmoi_install_script="$(curl -fsSL https://chezmoi.io/get)"
+  elif command -v wget >/dev/null; then
+    chezmoi_install_script="$(wget -qO- https://chezmoi.io/get)"
   else
     echo "To install chezmoi, you must have curl or wget installed." >&2
     exit 1
   fi
-else
-  chezmoi=chezmoi
+  sh -c "${chezmoi_install_script}" -- -b "${bin_dir}"
+  unset chezmoi_install_script bin_dir
 fi
 
 # POSIX way to get script's dir: https://stackoverflow.com/a/29834779/12156188
 script_dir="$(cd -P -- "$(dirname -- "$(command -v -- "$0")")" && pwd -P)"
-# exec: replace current process with chezmoi init
-exec "$chezmoi" init --apply "--source=$script_dir"
+
+set -- init --apply --source="${script_dir}"
+
+echo "Running 'chezmoi $*'" >&2
+# exec: replace current process with chezmoi
+exec "$chezmoi" "$@"


### PR DESCRIPTION
I updated my own `install.sh` with some improvements that I learned since then.

For example, `command -v curl >/dev/null` should be used instead of `[ "$(command -v curl)" ]`.

Let me know if you want to know something about the rest of the changes.
